### PR TITLE
Improve compatibility with kicad6 after 2021/3/14

### DIFF
--- a/netlist/src/helpers/netlist-parser.ls
+++ b/netlist/src/helpers/netlist-parser.ls
@@ -143,13 +143,19 @@ class NL_Component
   (@parser, @slist, @id=0) ->
     self = @
     self.attributes = {}    # default attributes: ref, value, footprint, sheetpath, datasheet, and tstamp
-    self.attributes['id'] = id
+    self.attributes['_id'] = id
     self.attributes['ref'] = ref = slist.dictionary['ref'][0].to_json yes
     self.attributes['value'] = slist.dictionary['value'][0].to_json yes
     self.attributes['footprint'] = slist.dictionary['footprint'][0].to_json yes
     self.attributes['sheetpath'] = slist.dictionary['sheetpath'][0].list[0].to_json yes
     self.attributes['datasheet'] = slist.dictionary['datasheet'][0].to_json yes if slist.dictionary['datasheet']?
-    self.attributes['tstamp'] = slist.dictionary['tstamp'][0].to_json yes
+    #
+    # At version "D", the format uses `(tstamp "00000000-0000-0000-0000-00005e2047d7"))`
+    # At version "E", the format uses `(tstamps "00000000-0000-0000-0000-00006bd3f023"))`
+    #
+    tstamp = slist.dictionary['tstamp']
+    tstamp = slist.dictionary['tstamps'] unless tstamp?
+    self.attributes['tstamp'] = tstamp[0].to_json yes
     self.aliases = parser.alias
     self.properties = {}
     [ (self.parse_property l) for l in slist.list ]

--- a/netlist/src/helpers/sql-mgr.ls
+++ b/netlist/src/helpers/sql-mgr.ls
@@ -6,7 +6,7 @@ TRACE = -> return console.error.apply null, arguments if global.verbose
 
 const SQL_CREATE_TABLE_FOR_COMPONENT = '''
   CREATE TABLE Component (
-    id INTEGER,
+    _id INTEGER,
     designator TEXT,
     rid INTEGER,
     ref TEXT,
@@ -17,7 +17,7 @@ const SQL_CREATE_TABLE_FOR_COMPONENT = '''
 
     OTHER_FIELDS
 
-    PRIMARY KEY("id")
+    PRIMARY KEY("_id")
   )
 '''
 
@@ -31,7 +31,7 @@ class SqlManager
     {db} = self = @
     {components} = parser
     self.tmp = {}
-    default_fields = <[id designator rid ref value footprint sheetpath datasheet]>
+    default_fields = <[_id designator rid ref value footprint sheetpath datasheet]>
     for c in components
       for k, v of c.properties
         self.tmp[k] = v


### PR DESCRIPTION
Since `kicad-unified-20210314-192940-0ed53c24ca-10_14`, kicad upgrades its netlist format from D to E, and using tstamps instead of tstamp. So, needs to improve netlist parser to compatible with the newer netlist format.